### PR TITLE
Update kbase dependency versions to 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,10 +21,10 @@
         "datatables": "^1.10.9",
         "datatables-bootstrap3-plugin": "^0.4.0",
         "numeral": "^1.5.0",
-        "kbase-common-js": "^0.1.0",
-        "kbase-ui-widget": "^0.1.0",
-        "kbase-service-clients-js": "^0.1.0",
-        "kbase-data-api-client-js": "^0.1.10"
+        "kbase-common-js": "^1.0.0",
+        "kbase-ui-widget": "^1.0.0",
+        "kbase-service-clients-js": "^1.0.0",
+        "kbase-data-api-client-js": "^1.0.0"
     },
     "devDependencies": {
     },


### PR DESCRIPTION
At this very moment, kbase-ui is building against my repo, because it won't build with < 1.0.0 internal dependencies in master any longer. As soon as this is merged, I'll update kbase-ui to point back here. Of course locally you can point to this repo or your local copy, which will work as long as the kbase- dependencies are updated to ^1.0.0.
