### PR TITLE
GA page updates

### DIFF
--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -73,30 +73,30 @@ install:
                     # to module is probably made above.
                     widget: 
                         name: kb_dataApiWidgets_assembly
- #       -
- #           type: 
- #               module: KBaseGenomes
- #               name:   ContigSet
- #               version: any
- #           icon: 
- #               type: fontAwesome
- #               classes: ['fa-list']
- #           viewers:
- #               -
- #                   # if set true, this will be set as the default vis widget for this type.
- #                   # note that we do not have a way of selecting one from amongst multiple widgets
- #                   default: true
- #                   # This the title for the widget if a wrapper panel is requested
- #                   title: 'Data View'
- #                   panel: false
- #                   # This is the widget id name as specified in the plugin
- #                   # it should follow standard namespacing. It should also be 
- #                   # defined above in the modules.
- #                   # module: kb_widget_dataview_communities_collection
- #                   # This is the registered widget id. The mapping of widget
- #                   # to module is probably made above.
- #                   widget: 
- #                       name: kb_dataApiWidgets_assembly
+        -
+            type: 
+                module: KBaseGenomes
+                name:   ContigSet
+                version: any
+            icon: 
+                type: fontAwesome
+                classes: ['fa-list']
+            viewers:
+                -
+                    # if set true, this will be set as the default vis widget for this type.
+                    # note that we do not have a way of selecting one from amongst multiple widgets
+                    default: true
+                    # This the title for the widget if a wrapper panel is requested
+                    title: 'Data View'
+                    panel: false
+                    # This is the widget id name as specified in the plugin
+                    # it should follow standard namespacing. It should also be 
+                    # defined above in the modules.
+                    # module: kb_widget_dataview_communities_collection
+                    # This is the registered widget id. The mapping of widget
+                    # to module is probably made above.
+                    widget: 
+                        name: kb_dataApiWidgets_assembly
         -
             type: 
                 module: KBaseGenomeAnnotations
@@ -120,4 +120,28 @@ install:
                     # This is the registered widget id. The mapping of widget
                     # to module is probably made above.
                     widget: 
-                        name: kb_dataApiWidgets_genome_annotation    
+                        name: kb_dataApiWidgets_genome_annotation
+        -
+            type: 
+                module: KBaseGenomes
+                name:   Genome
+                version: any
+            icon: 
+                type: fontAwesome
+                classes: ['fa-list']
+            viewers:
+                -
+                    # if set true, this will be set as the default vis widget for this type.
+                    # note that we do not have a way of selecting one from amongst multiple widgets
+                    default: true
+                    # This the title for the widget if a wrapper panel is requested
+                    title: 'Data View'
+                    panel: false
+                    # This is the widget id name as specified in the plugin
+                    # it should follow standard namespacing. It should also be 
+                    # defined above in the modules.
+                    # module: kb_widget_dataview_communities_collection
+                    # This is the registered widget id. The mapping of widget
+                    # to module is probably made above.
+                    widget: 
+                        name: kb_dataApiWidgets_genome_annotation

--- a/src/plugin/modules/widgets/genome_annotation.js
+++ b/src/plugin/modules/widgets/genome_annotation.js
@@ -176,7 +176,7 @@ define([
                                                   + "            </div>"
                                                   + "            <div>"
                                                   + "                <strong>DNA Sequence</strong>"
-                                                  + "                <div class='well wordwrap'>{{feature_dna_sequence}}</div>"
+                                                  + "                <div class='well wordwrap sequence'>{{feature_dna_sequence}}</div>"
                                                   + "            </div>"
                                                   + "            <div>"
                                                   + "                <div><strong>Aliases</strong></div>"
@@ -268,10 +268,6 @@ define([
                                     length: numeral(data[d].feature_locations[i].length).format('0,0')
                                 });
                             }
-                        }
-                        // TODO this is a hack for now, need to fix this in the API itself
-                        else if (item == 'feature_notes') {
-                            formattedData[d].feature_notes = data[d].feature_notes.join('');
                         }
                         else {
                             formattedData[d][item] = data[d][item];
@@ -457,7 +453,12 @@ define([
             }
             
             function renderTaxonLink(ref) {
-                container.querySelector('[data-element="taxonLink"]').innerHTML = "<a href='#dataview/" + ref + "'>Taxon</a>";
+                if (ref === null) {
+                    container.querySelector('[data-element="taxonLink"]').innerHTML = "Taxon"
+                }
+                else {
+                    container.querySelector('[data-element="taxonLink"]').innerHTML = "<a href='#dataview/" + ref + "'>Taxon</a>";
+                }
             }
             
             function renderTaxId(taxId) {
@@ -514,7 +515,12 @@ define([
                 
                 return genomeAnnotation.taxon()
                     .then(function (taxon_ref) {
-                        renderTaxonLink(taxon_ref);
+                        if (utils.getRef(params) === taxon_ref) {
+                            renderTaxonLink(null);
+                        }
+                        else {
+                            renderTaxonLink(taxon_ref);
+                        }
 
                         var taxon = Taxon.client({
                             url: runtime.getConfig('services.taxon_api.url'),
@@ -570,7 +576,12 @@ define([
                         });
                     })
                     .then(function (featureTypes) {
-                        var ftCounts = {}, ftypes = [], fcounts = [];
+                        var ftCounts = {},
+                            ftypes = [],
+                            fcounts = [],
+                            default_ftypes = ['gene','mRNA','CDS'],
+                            initial_type = null;
+                        
                         for(var f in featureTypes) {
                             if (featureTypes.hasOwnProperty(f)) {
                                 ftCounts[f] = numeral(featureTypes[f]).format('0,0');
@@ -582,14 +593,25 @@ define([
                         
                         renderFeatureTypesPlot(ftypes,fcounts);
                         renderFilterPanel(ftypes);
-                                                
+                            
+                        for (var i in default_ftypes) {
+                            if ($.inArray(default_ftypes[i],ftypes) > -1) {
+                                initial_type = default_ftypes[i];
+                                break;
+                            }
+                        }
+                            
+                        if (initial_type === null) {
+                            initial_type = ftypes.sort()[0];
+                        }
+                        
                         return genomeAnnotation.feature_ids({
                             filters: {
-                                type_list: ftypes
+                                type_list: [initial_type]
                             }
                         })
                         .then(function (feature_ids) {
-                            return genomeAnnotation.features(feature_ids.by_type[ftypes[0]].slice(0,1000));
+                            return genomeAnnotation.features(feature_ids.by_type[initial_type].slice(0,1000));
                         })
                         .then(function (feature_data) {
                             renderFeatureDataTable(feature_data);

--- a/src/plugin/resources/css/styles.css
+++ b/src/plugin/resources/css/styles.css
@@ -14,7 +14,15 @@
 }
 
 .wordwrap { 
-   word-wrap: break-word;
+    word-wrap: break-word;
+}
+
+.sequence {
+    font-family: "Courier New", Courier, monospace;
+}
+
+td {
+    word-wrap: break-word;
 }
 
 /*


### PR DESCRIPTION
- removing hack for notes field since now fixed at the API level and propagated
- better handling of display for Genome vs. GenomeAnnotation
- fixed width font for sequence
- by default select gene, mRNA, or CDS as selected feature type to display for feature table
- LP override for Genome and ContigSet
