### PR TITLE
Turn off default for contigset and genome viewers, enable ids

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "kbase-common-js": "^1.0.0",
     "kbase-ui-widget": "^1.0.0",
     "kbase-service-clients-js": "^1.0.0",
-    "kbase-data-api-client-js": "^1.0.2"
+    "kbase-data-api-client-js": "eapearson#develop"
   },
   "devDependencies": {},
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "kbase-common-js": "^1.0.0",
     "kbase-ui-widget": "^1.0.0",
     "kbase-service-clients-js": "^1.0.0",
-    "kbase-data-api-client-js": "eapearson#develop"
+    "kbase-data-api-client-js": "^1.0.2"
   },
   "devDependencies": {},
   "ignore": [

--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -87,7 +87,7 @@ install:
                     # only the default viewer will be available, and there is only one
                     # of those at a time.
                     # invoked like #dataview/ws/obj/ver?viewer=id
-                    id: dataapi
+                    id: data-landing-pages
                     # if set true, this will be set as the default vis widget for this type.
                     # note that we do not have a way of selecting one from amongst multiple widgets
                     default: false
@@ -136,7 +136,7 @@ install:
                 classes: ['fa-list']
             viewers:
                 -
-                    id: dataapi
+                    id: data-landing-pages
                     # if set true, this will be set as the default vis widget for this type.
                     # note that we do not have a way of selecting one from amongst multiple widgets
                     default: false

--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -83,6 +83,11 @@ install:
                 classes: ['fa-list']
             viewers:
                 -
+                    # If set, the id may be used to invoke a viewer directly. Otherwise
+                    # only the default viewer will be available, and there is only one
+                    # of those at a time.
+                    # invoked like #dataview/ws/obj/ver?viewer=id
+                    id: dataapi
                     # if set true, this will be set as the default vis widget for this type.
                     # note that we do not have a way of selecting one from amongst multiple widgets
                     default: false

--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -85,7 +85,7 @@ install:
                 -
                     # if set true, this will be set as the default vis widget for this type.
                     # note that we do not have a way of selecting one from amongst multiple widgets
-                    default: true
+                    default: false
                     # This the title for the widget if a wrapper panel is requested
                     title: 'Data View'
                     panel: false
@@ -131,9 +131,10 @@ install:
                 classes: ['fa-list']
             viewers:
                 -
+                    id: dataapi
                     # if set true, this will be set as the default vis widget for this type.
                     # note that we do not have a way of selecting one from amongst multiple widgets
-                    default: true
+                    default: false
                     # This the title for the widget if a wrapper panel is requested
                     title: 'Data View'
                     panel: false


### PR DESCRIPTION
In order to play nicely on CI, allowing the current production viewers to be available, there is now a strict enforcement of "default" rules. Previously it was loose. So there is only one default viewer allowed in the runtime, and there must be one for any type which has a viewer. In order to support alternative viewers (really only an issue for development at the moment since we have no ui support for this yet), a viewer may be provided with an id. The id needs to be unique within the module.type, so namespacing off of the plugin makes sense, so thus the ids are the plugin id. (If multiple viewers are needed they should be based on this.)
The alternate viewers are invoked like this:
http://localhost:8080/#dataview/8222/13/1?viewer=data-landing-pages
