### PR TITLE
Migrate Assembly/Taxon LP to SDK data api service with updates

### DIFF
--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -21,6 +21,13 @@ install:
             module: plugins/data-landing-pages/modules/widgets/assembly
             type: factory
         -
+            module: kb_dataApiWidgets_assemblyNarrativeTable
+            id: plugins/data-landing-pages/modules/widgets/kbaseGenomeAnnotationAssembly
+            title: Assembly View
+            config:
+                jqueryName: kbaseGenomeAnnotationAssembly
+            type: kbwidget
+        -
             id: kb_dataApiWidgets_genome_annotation
             module: plugins/data-landing-pages/modules/widgets/genome_annotation
             type: factory

--- a/src/plugin/modules/widgets/assembly.js
+++ b/src/plugin/modules/widgets/assembly.js
@@ -2,9 +2,9 @@
 /*jslint white: true, browser: true */
 define([
     'kb/common/html',
-    'kb/data/genomeAnnotation',
-    'kb/data/taxon',
-    'kb/data/assembly',
+    'kb_sdk_clients/GenomeAnnotationAPI/dev/GenomeAnnotationAPIClient',
+    'kb_sdk_clients/TaxonAPI/dev/TaxonAPIClient',
+    'kb_sdk_clients/AssemblyAPI/dev/AssemblyAPIClient',
     '../utils',
     'numeral',
     'handlebars',
@@ -271,41 +271,43 @@ define([
                 Array.from(container.querySelectorAll("[data-element]")).forEach(function (e) {
                     e.innerHTML = html.loading();
                 });
-                 
-                var contig_ids,
-                    contig_lengths,
-                    contigs_gc,
-                    assembly = Assembly.client({
-                        url: runtime.getConfig('services.assembly_api.url'),
-                        token: runtime.service('session').getAuthToken(),
-                        ref: utils.getRef(params),
-                        timeout: 900000
-                    });
                 
-                return assembly.number_contigs()
+                var assemblyRef = utils.getRef(params);
+
+                var assemblyClient = new Assembly({
+                                        url: runtime.getConfig('services.service_wizard.url'),
+                                        auth: {'token':runtime.service('session').getAuthToken()},
+                                        version: 'dev'
+                                    });
+
+                var contig_ids;
+                var contig_lengths;
+                var contigs_gc;
+
+                return assemblyClient.get_number_contigs(assemblyRef)
                     .then(function (numContigs) {
                         renderNumContigs(numContigs);
-                        return assembly.dna_size();
+                        return assemblyClient.get_dna_size(assemblyRef);
                     })
                     .then(function (dnaSize) {
                         renderDNASize(dnaSize);
-                        return assembly.gc_content();
+                        return assemblyClient.get_gc_content(assemblyRef);
                     })
                     .then(function (gc) {
                         renderGC(gc);
-                        return assembly.external_source_info();
+                        return assemblyClient.get_external_source_info(assemblyRef);
                     })
                     .then(function(external_source_info) {
                         renderExternalSourceInfo(external_source_info);
-                        return assembly.contig_ids();
+                        return assemblyClient.get_contig_ids(assemblyRef);
                     })
                     .then(function (ids) {
                         contig_ids = ids;
-                        return assembly.contig_lengths();
+                        return assemblyClient.get_contig_lengths(assemblyRef);
                     })
                     .then(function (lengths) {
                         contig_lengths = lengths;
-                        return assembly.contig_gc_content();
+                        return assemblyClient.get_contig_gc_content(assemblyRef);
                     })
                     .then(function (gc) {
                         contigs_gc = gc;

--- a/src/plugin/modules/widgets/assembly.js
+++ b/src/plugin/modules/widgets/assembly.js
@@ -256,7 +256,7 @@ define([
                 var assemblyClient = new Assembly({
                                         url: runtime.getConfig('services.service_wizard.url'),
                                         auth: {'token':runtime.service('session').getAuthToken()},
-                                        version: 'dev'
+                                        version: 'release'
                                     });
 
                 var contig_ids;
@@ -271,13 +271,13 @@ define([
                         })
                     );
                 plotDataCalls.push(
-                    assemblyClient.get_contig_lengths(assemblyRef)
+                    assemblyClient.get_contig_lengths(assemblyRef, null)
                         .then(function(lengths) {
                             contig_lengths = lengths;
                         })
                     );
                 plotDataCalls.push(
-                    assemblyClient.get_contig_gc_content(assemblyRef)
+                    assemblyClient.get_contig_gc_content(assemblyRef, null)
                         .then(function(gc) {
                             contigs_gc = gc;
                         })

--- a/src/plugin/modules/widgets/kbaseGenomeAnnotationAssembly.js
+++ b/src/plugin/modules/widgets/kbaseGenomeAnnotationAssembly.js
@@ -1,0 +1,259 @@
+
+define (
+    [
+        'kbwidget',
+        'bootstrap',
+        'jquery',
+        'kbase-client-api',
+        'jquery-dataTables',
+        'kbaseAuthenticatedWidget',
+        'kbaseTable',
+        'kbaseTabs',
+        'AssemblyAPI-client-api',
+        'narrativeConfig',
+        'bluebird'
+    ], function(
+        KBWidget,
+        bootstrap,
+        $,
+        kbase_client_api,
+        jquery_dataTables,
+        kbaseAuthenticatedWidget,
+        kbaseTable,
+        kbaseTabs,
+        AssemblyAPI_client_api,
+        Config,
+        Promise
+    ) {
+    'use strict';
+
+    return KBWidget({
+        name: "kbaseGenomeAnnotationAssembly",
+        parent : kbaseAuthenticatedWidget,
+        version: "1.0.0",
+        options: {
+
+
+        },
+
+        init: function init(options) {
+            this._super(options);
+
+            var $self = this;
+            $self.obj_ref = $self.options.wsNameOrId + '/' + $self.options.objNameOrId;
+            $self.link_ref = $self.obj_ref;
+
+            $self.assembly = new AssemblyAPI(Config.url('service_wizard'),{'token':$self.authToken()});
+            $self.ws = new Workspace(Config.url('workspace'),{'token':$self.authToken()});
+            
+            $self.$elem.append($('<div>').attr('align', 'center').append($('<i class="fa fa-spinner fa-spin fa-2x">')));
+
+            // 1) get stats, and show the panel
+            var basicInfoCalls = [];
+            basicInfoCalls.push(
+                $self.assembly.get_stats(this.obj_ref, null)
+                        .done(function(stats) {
+                            $self.assembly_stats = stats;
+                        }));
+            basicInfoCalls.push(
+                $self.ws.get_object_info_new({objects: [{'ref':this.obj_ref}], includeMetadata:1})
+                        .done(function(info) {
+                            $self.assembly_obj_info = info[0];
+                            $self.link_ref = info[0][6] + '/' + info[0][1] + '/' + info[0][4];
+                        }));
+            Promise.all(basicInfoCalls)
+                .then(function() {
+                   $self.renderBasicTable();
+                })
+                .catch(function(err) {
+                    $self.$elem.empty();
+                    $self.$elem.append('Error' + JSON.stringify(err));
+                });
+
+            return this;
+        },
+
+
+        processContigData: function() {
+            var $self = this;
+
+            var contig_table = [];
+            for (var id in $self.contig_lengths) {
+                if ($self.contig_lengths.hasOwnProperty(id)) {
+                    var gc='unknown';
+                    if($self.contig_lengths.hasOwnProperty(id)) {
+                        gc = String(($self.contig_gc[id]*100).toFixed(2)) + '%';
+                    }
+                    var contig = {
+                        id: id,
+                        len: '<!--' + $self.contig_lengths[id] + '-->' + String($self.numberWithCommas($self.contig_lengths[id]))+' bp',
+                        gc:  gc
+                    };
+                    contig_table.push(contig);
+                }
+            }
+            $self.contig_table = contig_table;
+            //console.log(contig_table);
+        },
+
+
+        renderBasicTable: function() {
+            var $self = this;
+            var $container = this.$elem;
+            $container.empty();
+
+            var $tabPane = $('<div>');
+            $container.append($tabPane);
+
+
+            // Build the overview table
+            var $overviewTable = $('<table class="table table-striped table-bordered table-hover" style="margin-left: auto; margin-right: auto;"/>');
+
+            function get_table_row(key, value) {
+                return $('<tr>').append($('<td>').append(key)).append($('<td>').append(value));
+            }
+
+            $overviewTable.append(get_table_row('KBase Object Name',
+                '<a href="/#dataview/'+$self.link_ref + '" target="_blank">' + $self.assembly_obj_info[1] +'</a>' ));
+                // leave out version for now, because that is not passed into data widgets
+                //'<a href="/#dataview/'+$self.link_ref + '" target="_blank">' + $self.assembly_obj_info[1] + ' (v'+$self.assembly_obj_info[4]+')'+'</a>' ));
+            $overviewTable.append(get_table_row('Number of Contigs', $self.assembly_stats['num_contigs'] ));
+            $overviewTable.append(get_table_row('Total GC Content',  String(($self.assembly_stats['gc_content']*100).toFixed(2)) + '%' ));
+            $overviewTable.append(get_table_row('Total Length',      String($self.numberWithCommas($self.assembly_stats['dna_size']))+' bp'  )  );
+            
+
+            // Build the tabs
+            var $tabs =  new kbaseTabs($tabPane, {
+                    tabPosition : 'top',
+                    canDelete : true, //whether or not the tab can be removed.
+                    tabs : [
+                        {
+                            tab : 'Assembly Summary',                               //name of the tab
+                            content : $('<div>').append($overviewTable),  //jquery object to stuff into the content
+                            canDelete : false,                             //override the canDelete param on a per tab basis
+                            show : true,      
+                        }, {
+                            tab : 'Contigs',
+                            canDelete : false,
+                            showContentCallback: function() { return $self.addContigList(); } // if you don't want to show the content right away, add a callback method that returns the content...
+                        },
+                    ],
+                }
+            );
+
+        },
+
+        addContigList: function() {
+            var $self = this;
+            var $content = $('<div>');
+            $self.$contigTablePanel = $content;
+
+
+            // Get contig lengths and gc, render the table
+            
+            $self.assembly_stats = {};
+            $self.contig_lengths = [];
+            $self.contig_gc = [];
+
+            var loadingCalls = [];
+            loadingCalls.push(
+                $self.assembly.get_contig_lengths(this.obj_ref, null)
+                            .done(function(lengths) {
+                                $self.contig_lengths = lengths;
+                            }));
+            loadingCalls.push(
+                $self.assembly.get_contig_gc_content(this.obj_ref, null)
+                    .done(function(gc) {
+                                $self.contig_gc = gc;
+                            }));
+
+            Promise.all(loadingCalls)
+                .then(function() {
+                    $self.processContigData();
+
+                    // sort extension for length- is there a better way?
+                    if(!$.fn.dataTableExt.oSort['genome-annotation-assembly-hidden-number-stats-pre']) {
+                        $.extend( $.fn.dataTableExt.oSort, {
+                            "genome-annotation-assembly-hidden-number-stats-pre": function ( a ) {
+                                // extract out the first comment if it exists, then parse as number
+                                var t = a.split('-->');
+                                if(t.length>1) {
+                                    var t2 = t[0].split('<!--');
+                                    if(t2.length>1) {
+                                        return Number(t2[1]);
+                                    }
+                                }
+                                return Number(a);
+                            },
+                            "genome-annotation-assembly-hidden-number-stats-asc": function( a, b ) {
+                                return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+                            },
+                            "genome-annotation-assembly-hidden-number-stats-desc": function(a,b) {
+                                return ((a < b) ? 1 : ((a > b) ? -1 : 0));
+                            }
+                        } );
+                    }
+
+                    ////////////////////////////// Contigs Tab //////////////////////////////
+                    var $table = $('<table class="table table-striped table-bordered table-hover" style="width: 100%; border: 1px solid #ddd; margin-left: auto; margin-right: auto;" >');
+
+                    var contigsPerPage = 10;
+                    var sDom = 'lft<ip>';
+                    if($self.contig_table.length<contigsPerPage) {
+                        sDom = 'fti';
+                    }
+
+                    var contigsSettings = {
+                        "bFilter": true,
+                        "sPaginationType": "full_numbers",
+                        "iDisplayLength": contigsPerPage,
+                        "aaSorting": [[ 1, "desc" ]],
+                        
+                        "sDom": sDom,
+
+                        "columns": [
+                            {sTitle: 'Contig Id', data: "id"},
+                            {sTitle: "Length", data: "len"},
+                            {sTitle: "GC Content", data: "gc"}
+                        ],
+                        "columnDefs": [
+                            { "type": "genome-annotation-assembly-hidden-number-stats", targets: [1] }
+                        ],
+                        "data": $self.contig_table,
+                        "language": {
+                            "lengthMenu": "_MENU_ Contigs per page",
+                            "zeroRecords": "No Matching Contigs Found",
+                            "info": "Showing _START_ to _END_ of _TOTAL_ Contigs",
+                            "infoEmpty": "No Contigs",
+                            "infoFiltered": "(filtered from _MAX_)",
+                            "search" : "Search Contigs"
+                        }
+                    };
+                    $content.empty();
+                    $content.append($('<div>').css('padding','10px 0px').append($table));
+                    $table.dataTable(contigsSettings);
+                })
+                .catch(function(err) {
+                    $content.empty();
+                    $content.append('Error' + JSON.stringify(err));
+                    console.err($self);
+                    console.err(err);
+                });
+            
+            return $content.append('<br>').append($('<div>').attr('align', 'center').append($('<i class="fa fa-spinner fa-spin fa-2x">')));
+        },
+
+        appendUI: function appendUI($elem) {
+          $elem.append("One day, there will be a widget here.")
+        },
+
+        numberWithCommas: function(x) {
+            //var parts = x.toString().split(".");
+            //parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            //return parts.join(".");
+            return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        }
+
+    });
+
+});

--- a/src/plugin/modules/widgets/kbaseGenomeAnnotationAssembly.js
+++ b/src/plugin/modules/widgets/kbaseGenomeAnnotationAssembly.js
@@ -45,7 +45,7 @@ define (
             $self.assembly = new Assembly({
                                         url: $self.runtime.getConfig('services.service_wizard.url'),
                                         auth: {'token':$self.runtime.service('session').getAuthToken()},
-                                        version: 'dev'
+                                        version: 'release'
                                     });
             $self.ws = new Workspace($self.runtime.getConfig('services.workspace.url'),{'token':$self.runtime.service('session').getAuthToken()});
             
@@ -54,12 +54,12 @@ define (
             // 1) get stats, and show the panel
             var basicInfoCalls = [];
             basicInfoCalls.push(
-                $self.assembly.get_stats($self.obj_ref, null)
+                $self.assembly.get_stats($self.obj_ref)
                         .then(function(stats) {
                             $self.assembly_stats = stats;
                         }));
             basicInfoCalls.push(
-                $self.assembly.get_external_source_info($self.obj_ref, null)
+                $self.assembly.get_external_source_info($self.obj_ref)
                         .then(function(info) {
                             $self.external_source_info = info;
                         }));


### PR DESCRIPTION
Painfully migrated the narrative assembly widget to this landing page, refactored some of the calls so things are grouped when possibly (rather than a separate call for each bit of information), and migrated to the new data api dynamic service.
