### PR TITLE
just commented out the statistics graphs [TASK-735]

### DIFF
--- a/src/plugin/modules/widgets/assembly.js
+++ b/src/plugin/modules/widgets/assembly.js
@@ -68,7 +68,9 @@ define([
 
             function intcmp(a, b) { return (a < b) ? -1 : ((a > b) ? 1 : 0); }
 
-            function renderPlots(contig_ids, gc, lengths, nxlen) {
+            // XXX - the renderPlots function is no longer actually used, since the statistics are disabled.
+            // leaving in, but commented out, for ease of restoration later.
+            /*function renderPlots(contig_ids, gc, lengths, nxlen) {
                 // Common settings
                 var marker_color = '#1C77B5',
                     nx_keys = _.map(_.keys(nxlen), function(key) { return key * 1; }),
@@ -152,7 +154,8 @@ define([
                             }
                         }
                     },
-                    */
+                    // THIS WAS A NESTED COMMENT. UN-NEST IT IF YOU RE-ENABLE renderPlots().
+                    * /
                     {
                         div: container.querySelector('div[data-element=\'contig_gc_vs_length\']'),
                         layout: {
@@ -214,7 +217,7 @@ define([
                     o.div.innerHTML = '';
                     plotly.newPlot(o.div, o.data, o.layout);
                 });
-            }
+            } */
 
 
             // WIDGET API
@@ -266,7 +269,8 @@ define([
                 var contig_lengths;
                 var contigs_gc;
 
-                var plotDataCalls = [];
+                // XXX - commenting out the Assembly Statistics, just in case we want to put 'em back in quickly
+                /*var plotDataCalls = [];
                 plotDataCalls.push(
                     assemblyClient.get_contig_ids(assemblyRef)
                         .then(function(ids) {
@@ -296,6 +300,7 @@ define([
                     .catch(function(err) {
                         console.error(err);
                     });
+                */
             }
 
             function stop() {

--- a/src/plugin/modules/widgets/assembly.js
+++ b/src/plugin/modules/widgets/assembly.js
@@ -19,12 +19,13 @@ define([
             var parent, container, runtime = config.runtime,
                 div = html.tag('div'),
                 templates = {
-                    overview: 
+                    overview:
                           '<div class=\'row\'>'
                         + '    <div class=\'col-md-12 overview-content\'>'
                         + '    </div>'
                         + '</div>',
-                    quality: '<div class=\'row\'>'
+                    // XXX - commenting out the Assembly Statistics, just in case we want to put 'em back in quickly
+                    /*quality: '<div class=\'row\'>'
                            + '    <div class=\'col-md-5 col-md-offset-1\'>'
                            + '        <div data-element=\'contig_gc_hist\'></div>'
                            + '    </div>'
@@ -39,7 +40,7 @@ define([
                            + '    <div class=\'col-md-5\'>'
                            + '        <div data-element=\'nx_plot\'></div>'
                            + '    </div>'
-                           + '</div>',
+                           + '</div>',*/
                     annotations: '<div class=\'row\'>'
                                + '    <div data-element=\'linked_annotations\'></div>'
                                + '</div>',
@@ -48,7 +49,7 @@ define([
                           + '</div>'
                 };
 
-                
+
             // VIEW
 
             function layout() {
@@ -57,10 +58,11 @@ define([
                         title: 'Assembly Summary',
                         content: div({id: 'overview'}, html.loading())
                     }),
-                    html.makePanel({
+                    // XXX - commenting out the Assembly Statistics, just in case we want to put 'em back in quickly
+                    /*html.makePanel({
                         title: 'Assembly Statistics',
                         content: div({id: 'quality'}, html.loading())
-                    })                    
+                    })*/
                 ]);
             }
 
@@ -213,7 +215,7 @@ define([
                     plotly.newPlot(o.div, o.data, o.layout);
                 });
             }
-            
+
 
             // WIDGET API
 
@@ -232,14 +234,15 @@ define([
                  *   objectVersion
                  *   ...
                  */
-                
+
                 container.querySelector('div[id="overview"]').innerHTML = templates.overview;
-                container.querySelector('div[id="quality"]').innerHTML = templates.quality;
- 
+                // XXX - commenting out the Assembly Statistics, just in case we want to put 'em back in quickly
+                //container.querySelector('div[id="quality"]').innerHTML = templates.quality;
+
                 Array.from(container.querySelectorAll('[data-element]')).forEach(function (e) {
                     e.innerHTML = html.loading();
                 });
-                
+
                 // get the assembly reference
                 var assemblyRef = utils.getRef(params);
 
@@ -301,10 +304,10 @@ define([
 
             function detach() {
                 // nothing to do necessarily, since the parent dom node will
-                // be removed the controller for this widget removes it, 
+                // be removed the controller for this widget removes it,
                 // but it is nice to take responsibility for undoing what we
                 // changed in the parent node:
-                
+
                 if (parent && container) {
                     container.innerHTML = '';
                     parent.removeChild(container);


### PR DESCRIPTION
TASK-735 is still a little vaguely defined, and we haven't had people around to answer questions about it.

This pull does one (1) thing - it comments out the Assembly Statistics graphs at the bottom. Note that the code is commented as opposed to removed for simplicity in restoring it, but once we're sure that we want 'em gone it should be nuked.

The task also indicates that there's a 502 for the summary section...but I don't have an assembly object to test that against, so that's untouched.
And it already has a contig viewer, which appears to be the same as the Narrative widget, albeit in a different location.

More info from the reporter is required to address those last two issues, but this at least shows _something_ being tweaked.